### PR TITLE
Support eks IAM permissions

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "iam_policy_names" {
   description = "(Optional) List of IAM policy names to apply to the instance."
 
   default = [
-    "KOPS_MANAGEMENT_NODE_autoscaling_elb",
+    "KOPS_MANAGEMENT_NODE_autoscaling_elb_eks",
     "KOPS_MANAGEMENT_NODE_lma",
     "KOPS_MANAGEMENT_NODE_dynamodb",
     "KOPS_MANAGEMENT_NODE_ec2",


### PR DESCRIPTION
This change is dependent on PR https://github.com/kentrikos/aws-bootstrap/pull/33 for the aws-bootstrap repo (i.e. new permissions for EKS)